### PR TITLE
Add imagePullSecrets values at gslb-controller

### DIFF
--- a/citrix-gslb-controller/templates/rbac.yaml
+++ b/citrix-gslb-controller/templates/rbac.yaml
@@ -65,5 +65,10 @@ kind: ServiceAccount
 metadata:
   name: {{ include "citrix-gslb-controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+- name: {{.}}
+{{- end }}
+{{- end }}
 ---

--- a/citrix-gslb-controller/values.yaml
+++ b/citrix-gslb-controller/values.yaml
@@ -7,6 +7,7 @@ imageRegistry: quay.io
 imageRepository: citrix/citrix-k8s-ingress-controller
 imageTag: 1.39.6
 image: "{{ .Values.imageRegistry }}/{{ .Values.imageRepository }}:{{ .Values.imageTag }}"
+imagePullSecrets: []
 pullPolicy: IfNotPresent
 # openshift is set to true if charts are being deployed in OpenShift environment.
 openshift: false

--- a/netscaler-gslb-controller/templates/rbac.yaml
+++ b/netscaler-gslb-controller/templates/rbac.yaml
@@ -65,5 +65,10 @@ kind: ServiceAccount
 metadata:
   name: {{ include "netscaler-gslb-controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+  - name: {{.}}
+{{- end }}
+{{- end }}
 ---

--- a/netscaler-gslb-controller/values.yaml
+++ b/netscaler-gslb-controller/values.yaml
@@ -7,6 +7,7 @@ imageRegistry: quay.io
 imageRepository: netscaler/netscaler-k8s-ingress-controller
 imageTag: 1.39.6
 image: "{{ .Values.imageRegistry }}/{{ .Values.imageRepository }}:{{ .Values.imageTag }}"
+imagePullSecrets: []
 pullPolicy: IfNotPresent
 # openshift is set to true if charts are being deployed in OpenShift environment.
 openshift: false


### PR DESCRIPTION
This Pull Request addresses the issue where gslb-operator was unable to pull images from a private container registry due to missing imagePullSecrets configuration. 

I've edited the Helm templates for `citrix-gslb-controller` and `netscaler-gslb-controller` to include imagePullSecrets configuration.

To verify the fix, I confirmed successful application using the following commands:
```
$ helm template citrix-gslb-controller --set localRegion=site1 --set localCluster=test --set "imagePullSecrets={example-token}"

$ helm template netscaler-gslb-controller --set localRegion=site1 --set localCluster=test --set "imagePullSecrets={example-token}"
```